### PR TITLE
feat: Add scoped support for Emerald paratime ORC file

### DIFF
--- a/inventory/group_vars/mainnet_emerald_nodes.yml
+++ b/inventory/group_vars/mainnet_emerald_nodes.yml
@@ -4,6 +4,7 @@ network: mainnet
 node_type: emerald
 node_user: emerald
 node_mode: compute
+emerald_runtime_version: "v11.0.0"
 runtimes:
   - id: "000000000000000000000000000000000000000000000000e2eaa99fc008f87f"
     name: "Emerald"

--- a/inventory/group_vars/mainnet_mixed_nodes.yml
+++ b/inventory/group_vars/mainnet_mixed_nodes.yml
@@ -4,6 +4,7 @@ network: mainnet
 node_type: mixed
 node_user: oasis
 node_mode: compute
+emerald_runtime_version: "v11.0.0"
 consensus_validator: false
 # The `runtimes` list for a mixed node is defined per-host in inventory/hosts.yml
 port_offset: 4 # Using a new offset to avoid conflicts

--- a/inventory/group_vars/testnet_emerald_nodes.yml
+++ b/inventory/group_vars/testnet_emerald_nodes.yml
@@ -4,6 +4,7 @@ network: testnet
 node_type: emerald
 node_user: temerald
 node_mode: compute
+emerald_runtime_version: "v11.0.0"
 runtimes:
   - id: "00000000000000000000000000000000000000000000000072c8215e60d5bca7"
     name: "Emerald"

--- a/inventory/group_vars/testnet_mixed_nodes.yml
+++ b/inventory/group_vars/testnet_mixed_nodes.yml
@@ -4,6 +4,7 @@ network: testnet
 node_type: mixed
 node_user: noasis
 node_mode: compute
+emerald_runtime_version: "v11.0.0"
 consensus_validator: false
 # The `runtimes` list for a mixed node is defined per-host in inventory/hosts.yml
 port_offset: 14 # Using a new offset for testnet to avoid conflicts

--- a/roles/oasis_node/tasks/install.yml
+++ b/roles/oasis_node/tasks/install.yml
@@ -37,6 +37,7 @@
     - { path: '/home/{{ node_user }}/bin', mode: '0755' }
     - { path: '/home/{{ node_user }}/data', mode: '0700' }
     - { path: '/home/{{ node_user }}/etc', mode: '0755' }
+    - { path: '/home/{{ node_user }}/runtimes', mode: '0755' }
 
 - name: Download and unarchive Oasis Core binary
   unarchive:
@@ -68,6 +69,23 @@
     group: "{{ node_user }}"
     mode: '0644'
   when: not genesis_file.stat.exists
+
+- name: Check if Emerald runtime file exists
+  stat:
+    path: "/home/{{ node_user }}/runtimes/emerald-paratime.orc"
+  register: emerald_runtime_file
+  when: emerald_runtime_version is defined
+
+- name: Download Emerald runtime file
+  get_url:
+    url: "https://github.com/oasisprotocol/emerald-paratime/releases/download/{{ emerald_runtime_version }}{{ '-testnet' if network == 'testnet' else '' }}/emerald-paratime.orc"
+    dest: "/home/{{ node_user }}/runtimes/emerald-paratime.orc"
+    owner: "{{ node_user }}"
+    group: "{{ node_user }}"
+    mode: '0755'
+  when:
+    - emerald_runtime_version is defined
+    - not emerald_runtime_file.stat.exists
 
 - name: Get latest block height
   uri:

--- a/roles/oasis_node/templates/config.yml.j2
+++ b/roles/oasis_node/templates/config.yml.j2
@@ -50,6 +50,10 @@ consensus:
 runtime:
   environment: sgx
   sgx_loader: /home/{{ node_user }}/bin/oasis-core-runtime-loader
+  paths:
+{% if emerald_runtime_version is defined %}
+    - /home/{{ node_user }}/runtimes/emerald-paratime.orc
+{% endif %}
   runtimes:
 {% for runtime in runtimes %}
     - id: "{{ runtime.id }}"    # {{ runtime.name }}


### PR DESCRIPTION
This change introduces support for the Emerald paratime ORC file, which is required for nodes running the Emerald runtime.

Key changes include:

- A new `emerald_runtime_version` variable is used to define the ORC file version, making future updates easier. This variable is specifically scoped to the `mainnet_emerald_nodes`, `testnet_emerald_nodes`, `mainnet_mixed_nodes`, and `testnet_mixed_nodes` inventory groups to ensure it only applies to nodes that require the Emerald runtime.

- The Ansible `install.yml` task is updated to:
  1. Create a dedicated `/home/{{ node_user }}/runtimes` directory for paratime files.
  2. Conditionally download the Emerald ORC file using a dynamic URL constructed from the `emerald_runtime_version`. The download only occurs if the `emerald_runtime_version` variable is defined for the host.

- The `config.yml.j2` template is updated to conditionally include the path to the downloaded ORC file in the node's configuration.